### PR TITLE
update go mod

### DIFF
--- a/compute/metadata/fake/go.mod
+++ b/compute/metadata/fake/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	cloud.google.com/go/iam v0.3.0
-	github.com/zchee/gce-metadata-server v0.0.0-20220612121039-8d07a83b2cf2
 	golang.org/x/net v0.0.0-20220607020251-c690dde0001d
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb
 	google.golang.org/api v0.83.0
@@ -17,6 +16,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
+	github.com/zchee/gce-metadata-server v0.0.0-20220614120728-0750052a9ff2 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/compute/metadata/fake/go.sum
+++ b/compute/metadata/fake/go.sum
@@ -194,6 +194,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zchee/gce-metadata-server v0.0.0-20220612121039-8d07a83b2cf2 h1:81Lc7wFZBH22oYVNcE3QwzJBybf2qwXkNPh3XcjY8RY=
 github.com/zchee/gce-metadata-server v0.0.0-20220612121039-8d07a83b2cf2/go.mod h1:enju0X9A1heVrldvICoyx1Y/EKGUnUf1PdeTf//kpco=
+github.com/zchee/gce-metadata-server v0.0.0-20220614120728-0750052a9ff2 h1:HL5Pb/fz35LeG04nNdcoEMeqgR36REusASgmgJPUXw8=
+github.com/zchee/gce-metadata-server v0.0.0-20220614120728-0750052a9ff2/go.mod h1:oijEOH9OM75ZdyCcOe1SYyD3YUFp6nbsMG6tfgDU4dg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
# what
for fake package

# why
- `v0.0.0-20220612121039-8d07a83b2cf2` is unknown package

# how
1. remove this package from go.mod
2. run command below:
```shell
GOPRIVATE=github.com/zchee/gce-metadata-server go get github.com/zchee/gce-metadata-server@main
```